### PR TITLE
Bug Fix: streaming data with io.BytesIO, default body return value

### DIFF
--- a/stackinabox/util_requests_mock.py
+++ b/stackinabox/util_requests_mock.py
@@ -94,6 +94,10 @@ class RequestMockCallable(object):
         elif isinstance(body, six.binary_type):
             content_data = body
 
+        else:
+            # default to body data
+            body_data = body
+
         return requests_mock.response.create_response(
             request,
             headers=output_headers,


### PR DESCRIPTION
- If the caller returned an object capable of streaming data, such as io.BytesIO, then it was not getting recognized as providing body content and thus nothing was being returned back to the caller.