### PR TITLE
Enhancement errors update

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -89,6 +89,16 @@ Out-of-the-box it supports the following frameworks:
 
 You can use any of them, and you must pull them in via your own test requirements.
 
+-----------
+Error Codes
+-----------
+
+StackInABox has some specific error codes to help with diagnosing issues:
+
+- 597 - StackInABox - Base URL is correct, but service is unknown
+- 596 - StackInABox - Handling StackInABoxService generated an exception
+- 595 - StackInABoxService - Route Not handled 
+
 Both of these are extremely easy to use as shown in the following examples:
 
 ---------

--- a/stackinabox/services/service.py
+++ b/stackinabox/services/service.py
@@ -96,7 +96,7 @@ class StackInABoxServiceRouter(object):
                                         request,
                                         uri,
                                         headers)
-        else:
+        elif self.obj is not None:
             logger.debug('Service Router ({0} - {1}): Located Subservice {2} '
                          'on Route {3}. Calling...'
                          .format(id(self),
@@ -108,6 +108,16 @@ class StackInABoxServiceRouter(object):
                                         request,
                                         uri,
                                         headers)
+
+        else:
+            logger.debug('Service Router ({0} - {1}): '
+                         'No Method handler for service'
+                         .format(id(self),
+                                 self.service_name))
+            return (405,
+                    headers,
+                    '{0} not supported. Supported Methods are {1}'.format(
+                        method, self.methods))
 
 
 class StackInABoxService(object):
@@ -236,7 +246,7 @@ class StackInABoxService(object):
                                      request,
                                      uri,
                                      headers)
-        return (500, headers, 'Server Error')
+        return (599, headers, 'Server Error')
 
     def request(self, method, request, uri, headers):
         logger.debug('StackInABoxService ({0}:{1}): Request Received {2} - {3}'

--- a/stackinabox/services/service.py
+++ b/stackinabox/services/service.py
@@ -246,7 +246,7 @@ class StackInABoxService(object):
                                      request,
                                      uri,
                                      headers)
-        return (599, headers, 'Server Error')
+        return (595, headers, 'Route ({0}) Not Handled'.format(uri))
 
     def request(self, method, request, uri, headers):
         logger.debug('StackInABoxService ({0}:{1}): Request Received {2} - {3}'

--- a/stackinabox/stack.py
+++ b/stackinabox/stack.py
@@ -134,6 +134,7 @@ class StackInABox(object):
         logger.debug('StackInABox({0}): Received call to {1} - {2}'
                      .format(self.__id, method, uri))
         service_uri = StackInABox.__get_services_url(uri, self.base_url)
+
         for k, v in six.iteritems(self.services):
             matcher, service = v
             logger.debug('StackInABox({0}): Checking if Service {1} handles...'
@@ -155,7 +156,7 @@ class StackInABox(object):
                     logger.exception('StackInABox({0}): Service {1} - '
                                      'Internal Failure'
                                      .format(self.__id, service.name))
-                    return (500,
+                    return (599,
                             headers,
                             'Service Handler had an error: {0}'.format(ex))
         return (500, headers, 'Unknown service')

--- a/stackinabox/stack.py
+++ b/stackinabox/stack.py
@@ -69,7 +69,7 @@ class StackInABox(object):
         return '{0}/{1}'.format(base_url, service_name)
 
     @staticmethod
-    def __get_services_url(url, base_url):
+    def get_services_url(url, base_url):
         length = len(base_url)
         checks = ['http://', 'https://']
         for check in checks:
@@ -117,7 +117,7 @@ class StackInABox(object):
         if service.name not in self.services.keys():
             logger.debug('StackInABox({0}): Registering Service {1}'
                          .format(self.__id, service.name))
-            regex = '^/{0}'.format(service.name)
+            regex = '^/{0}/'.format(service.name)
             self.services[service.name] = [
                 re.compile(regex),
                 service
@@ -133,7 +133,7 @@ class StackInABox(object):
     def call(self, method, request, uri, headers):
         logger.debug('StackInABox({0}): Received call to {1} - {2}'
                      .format(self.__id, method, uri))
-        service_uri = StackInABox.__get_services_url(uri, self.base_url)
+        service_uri = StackInABox.get_services_url(uri, self.base_url)
 
         for k, v in six.iteritems(self.services):
             matcher, service = v
@@ -156,10 +156,10 @@ class StackInABox(object):
                     logger.exception('StackInABox({0}): Service {1} - '
                                      'Internal Failure'
                                      .format(self.__id, service.name))
-                    return (599,
+                    return (598,
                             headers,
                             'Service Handler had an error: {0}'.format(ex))
-        return (500, headers, 'Unknown service')
+        return (599, headers, 'Unknown service')
 
     def into_hold(self, name, obj):
         logger.debug('StackInABox({0}): Holding onto {1} of type {2} '

--- a/stackinabox/stack.py
+++ b/stackinabox/stack.py
@@ -156,10 +156,10 @@ class StackInABox(object):
                     logger.exception('StackInABox({0}): Service {1} - '
                                      'Internal Failure'
                                      .format(self.__id, service.name))
-                    return (598,
+                    return (596,
                             headers,
                             'Service Handler had an error: {0}'.format(ex))
-        return (599, headers, 'Unknown service')
+        return (597, headers, 'Unknown service - {0}'.format(service_uri))
 
     def into_hold(self, name, obj):
         logger.debug('StackInABox({0}): Holding onto {1} of type {2} '

--- a/stackinabox/tests/test_httpretty.py
+++ b/stackinabox/tests/test_httpretty.py
@@ -73,7 +73,10 @@ class TestHttprettyAdvanced(unittest.TestCase):
         self.assertEqual(res.text, 'okay')
 
         res = requests.get('http://localhost/advanced/_234567890')
-        self.assertEqual(res.status_code, 500)
+        self.assertEqual(res.status_code, 599)
 
         res = requests.put('http://localhost/advanced/h')
+        self.assertEqual(res.status_code, 405)
+
+        res = requests.put('http://localhost/advanced2/i')
         self.assertEqual(res.status_code, 599)

--- a/stackinabox/tests/test_httpretty.py
+++ b/stackinabox/tests/test_httpretty.py
@@ -73,10 +73,10 @@ class TestHttprettyAdvanced(unittest.TestCase):
         self.assertEqual(res.text, 'okay')
 
         res = requests.get('http://localhost/advanced/_234567890')
-        self.assertEqual(res.status_code, 599)
+        self.assertEqual(res.status_code, 595)
 
         res = requests.put('http://localhost/advanced/h')
         self.assertEqual(res.status_code, 405)
 
         res = requests.put('http://localhost/advanced2/i')
-        self.assertEqual(res.status_code, 599)
+        self.assertEqual(res.status_code, 597)

--- a/stackinabox/tests/test_httpretty.py
+++ b/stackinabox/tests/test_httpretty.py
@@ -76,4 +76,4 @@ class TestHttprettyAdvanced(unittest.TestCase):
         self.assertEqual(res.status_code, 500)
 
         res = requests.put('http://localhost/advanced/h')
-        self.assertEqual(res.status_code, 500)
+        self.assertEqual(res.status_code, 599)

--- a/stackinabox/tests/test_requests_mock.py
+++ b/stackinabox/tests/test_requests_mock.py
@@ -87,9 +87,12 @@ class TestRequestMockAdvanced(unittest.TestCase):
         self.assertEqual(res.text, 'okay')
 
         res = self.session.get('http://localhost/advanced/_234567890')
-        self.assertEqual(res.status_code, 500)
+        self.assertEqual(res.status_code, 599)
 
         res = self.session.put('http://localhost/advanced/h')
+        self.assertEqual(res.status_code, 405)
+
+        res = self.session.put('http://localhost/advanced2/i')
         self.assertEqual(res.status_code, 599)
 
     def test_context_requests_mock(self):

--- a/stackinabox/tests/test_requests_mock.py
+++ b/stackinabox/tests/test_requests_mock.py
@@ -87,13 +87,13 @@ class TestRequestMockAdvanced(unittest.TestCase):
         self.assertEqual(res.text, 'okay')
 
         res = self.session.get('http://localhost/advanced/_234567890')
-        self.assertEqual(res.status_code, 599)
+        self.assertEqual(res.status_code, 595)
 
         res = self.session.put('http://localhost/advanced/h')
         self.assertEqual(res.status_code, 405)
 
         res = self.session.put('http://localhost/advanced2/i')
-        self.assertEqual(res.status_code, 599)
+        self.assertEqual(res.status_code, 597)
 
     def test_context_requests_mock(self):
         with stackinabox.util_requests_mock.activate():

--- a/stackinabox/tests/test_requests_mock.py
+++ b/stackinabox/tests/test_requests_mock.py
@@ -90,7 +90,7 @@ class TestRequestMockAdvanced(unittest.TestCase):
         self.assertEqual(res.status_code, 500)
 
         res = self.session.put('http://localhost/advanced/h')
-        self.assertEqual(res.status_code, 500)
+        self.assertEqual(res.status_code, 599)
 
     def test_context_requests_mock(self):
         with stackinabox.util_requests_mock.activate():

--- a/stackinabox/tests/test_responses.py
+++ b/stackinabox/tests/test_responses.py
@@ -65,13 +65,13 @@ def test_advanced_responses():
         assert res.text == 'okay'
 
         res = requests.get('http://localhost/advanced/_234567890')
-        assert res.status_code == 599
+        assert res.status_code == 595
 
         res = requests.put('http://localhost/advanced/h')
         assert res.status_code == 405
 
         res = requests.put('http://localhost/advanced2/i')
-        assert res.status_code == 599
+        assert res.status_code == 597
 
         StackInABox.reset_services()
 

--- a/stackinabox/tests/test_responses.py
+++ b/stackinabox/tests/test_responses.py
@@ -68,7 +68,7 @@ def test_advanced_responses():
         assert res.status_code == 500
 
         res = requests.put('http://localhost/advanced/h')
-        assert res.status_code == 500
+        assert res.status_code == 599
 
         StackInABox.reset_services()
 

--- a/stackinabox/tests/test_responses.py
+++ b/stackinabox/tests/test_responses.py
@@ -65,9 +65,12 @@ def test_advanced_responses():
         assert res.text == 'okay'
 
         res = requests.get('http://localhost/advanced/_234567890')
-        assert res.status_code == 500
+        assert res.status_code == 599
 
         res = requests.put('http://localhost/advanced/h')
+        assert res.status_code == 405
+
+        res = requests.put('http://localhost/advanced2/i')
         assert res.status_code == 599
 
         StackInABox.reset_services()

--- a/stackinabox/tests/test_stack.py
+++ b/stackinabox/tests/test_stack.py
@@ -1,0 +1,63 @@
+import re
+import unittest
+
+import ddt
+import httpretty
+import requests
+
+import stackinabox.util_httpretty
+from stackinabox.stack import (
+    StackInABox, ServiceAlreadyRegisteredError)
+from stackinabox.services.service import *
+from stackinabox.services.hello import HelloService
+
+
+class ExceptionalServices(StackInABoxService):
+
+    def __init__(self):
+        super(ExceptionalServices, self).__init__('except')
+        self.register(StackInABoxService.GET,
+                      '/',
+                      ExceptionalServices.handler)
+
+    def handler(self, request, uri, headers):
+        raise Exception('Exceptional Service Failure')
+
+
+@ddt.ddt
+class TestStack(unittest.TestCase):
+
+    def setUp(self):
+        super(TestStack, self).setUp()
+
+    def tearDown(self):
+        super(TestStack, self).tearDown()
+        StackInABox.reset_services()
+
+    def test_double_service_registration(self):
+        service1 = HelloService()
+        service2 = HelloService()
+
+        StackInABox.register_service(service1)
+        with self.assertRaises(ServiceAlreadyRegisteredError):
+            StackInABox.register_service(service2)
+
+    @ddt.data(
+        ('http://honeymoon/', 'honeymoon', '/'),
+        ('https://honeymoon/', 'honeymoon', '/'),
+        ('honeymoon/', 'honeymoon', '/')
+    )
+    @ddt.unpack
+    def test_get_services_url(self, url, base, value):
+        result = StackInABox.get_services_url(url, base)
+        self.assertEqual(result, value)
+
+    @httpretty.activate
+    def test_service_exception(self):
+        exceptional = ExceptionalServices()
+        StackInABox.register_service(exceptional)
+
+        stackinabox.util_httpretty.httpretty_registration('localhost')
+
+        res = requests.get('http://localhost/except/')
+        self.assertEqual(res.status_code, 598)

--- a/stackinabox/tests/test_stack.py
+++ b/stackinabox/tests/test_stack.py
@@ -60,4 +60,4 @@ class TestStack(unittest.TestCase):
         stackinabox.util_httpretty.httpretty_registration('localhost')
 
         res = requests.get('http://localhost/except/')
-        self.assertEqual(res.status_code, 598)
+        self.assertEqual(res.status_code, 596)

--- a/stackinabox/tests/utils/services.py
+++ b/stackinabox/tests/utils/services.py
@@ -8,6 +8,9 @@ from six.moves.urllib import parse
 from stackinabox.services.service import StackInABoxService
 
 
+logger = logging.getLogger(__name__)
+
+
 class AdvancedService(StackInABoxService):
 
     def __init__(self):

--- a/stackinabox/util_httpretty.py
+++ b/stackinabox/util_httpretty.py
@@ -6,6 +6,8 @@ import re
 
 from httpretty import register_uri
 from httpretty.http import HttpBaseClass
+import httpretty.http
+import six
 
 from stackinabox.stack import StackInABox
 from stackinabox.utils import CaseInsensitiveDict
@@ -28,6 +30,16 @@ def httpretty_callback(request, uri, headers):
 
 
 def httpretty_registration(uri):
+
+    status_data = {
+        595: 'StackInABoxService - Unknown Route',
+        596: 'StackInABox - Exception in Service Handler',
+        597: 'StackInABox - Unknown Service'
+    }
+    for k, v in six.iteritems(status_data):
+        if k not in httpretty.http.STATUSES:
+            httpretty.http.STATUSES[k] = v
+
     logger.debug('Registering Stack-In-A-Box at {0} under Python HTTPretty'
                  .format(uri))
     StackInABox.update_uri(uri)

--- a/tools/test-requirements.txt
+++ b/tools/test-requirements.txt
@@ -1,4 +1,5 @@
 coverage
+ddt
 httpretty==0.8.8
 nose
 nose-exclude


### PR DESCRIPTION
- Use specific error codes for certain events within StackInABox to make debugging easier
  - returns 597 if the service is unknown
  - returns 596 if an unhandled exception occurred within the service
  - returns 595 if the service did not recognize the route
- Return 405 if the URI is handled but the specific METHOD on the URI is not.